### PR TITLE
Added pygments package as a dependency. Fixes #10.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ slackclient==1.0.0
 wcwidth==0.1.6
 websocket-client==0.37.0
 wsgiref==0.1.2
+pygments==2.1.3


### PR DESCRIPTION
On Mac OS X El Capitan, pygments package is required.
